### PR TITLE
Use syscall.Exec() to execute commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: compile build build_all fmt lint test itest vet bootstrap
-	
+
 SOURCE_FOLDER := .
 
 BINARY_PATH ?= ./bin/configo
@@ -15,17 +15,15 @@ SPECS ?= spec/integration/**
 export GO15VENDOREXPERIMENT=1
 
 default: build
-	
+
 build_all: vet fmt
-	for GOOS in darwin linux windows; do \
-		$(MAKE) compile GOOS=$$GOOS GOARCH=amd64 ; \
-	done
+	$(MAKE) compile GOOS=linux GOARCH=amd64
 
 compile:
-	CGO_ENABLED=0 go build -i -v -ldflags '-s' -o $(BINARY_PATH) $(SOURCE_FOLDER)/
+	go build -i -v -ldflags '-s' -o $(BINARY_PATH) $(SOURCE_FOLDER)/
 
 build: vet fmt compile
-	
+
 fmt:
 	go fmt $(glide novendor)
 
@@ -37,7 +35,7 @@ lint:
 
 test:
 	go test $(glide novendor)
-	
+
 itest:
 	$(MAKE) compile GOOS=linux GOARCH=amd64
 	bats $(SPECS)

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   environment:
-    GO15VENDOREXPERIMENT: 1
+    GOROOT: ""
+    PATH: "/usr/local/go/bin:/usr/local/go_workspace/bin:~/.go_workspace/bin:${PATH}"
+    GOPATH: "${HOME}/.go_workspace:/usr/local/go_workspace"
 dependencies:
   pre:
     - make bootstrap

--- a/glide.lock
+++ b/glide.lock
@@ -1,374 +1,83 @@
-hash: c2aa4518d87d25f7cfde3407227b2872c353bb8535cc2bed0ca8a2477f287c56
-updated: 2016-02-09T13:24:11.50673826+02:00
+hash: e753147e703cca95362c11e0e09c4d8b88936bd951016f30d7659df54d56da2d
+updated: 2017-03-09T16:43:21.697554112Z
 imports:
 - name: github.com/ahmetalpbalkan/go-linq
   version: 32a9c2bd73213b024e8bd5a687927eaf9bdfe0b9
-- name: github.com/armon/circbuf
-  version: bbbad097214e2918d8543d5201d12bfd7bca254d
-- name: github.com/armon/go-metrics
-  version: 345426c77237ece5dab0e1605c3e4b35c3f54757
-  subpackages:
-  - datadog
-- name: github.com/armon/go-radix
-  version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
-- name: github.com/asaskevich/govalidator
-  version: 129580890d97de923d9d9aec06cb1aa771812aff
 - name: github.com/aws/aws-sdk-go
   version: 87b1e60a50b09e4812dee560b33a238f67305804
   subpackages:
   - aws
-  - aws/credentials
-  - aws/defaults
-  - aws/session
-  - service/dynamodb
-  - service/dynamodb/dynamodbattribute
   - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
   - aws/corehandlers
+  - aws/credentials
   - aws/credentials/ec2rolecreds
+  - aws/defaults
   - aws/ec2metadata
   - aws/request
+  - aws/session
   - private/endpoints
-  - aws/client
-  - aws/awsutil
-  - aws/client/metadata
+  - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
+  - private/protocol/rest
   - private/signer/v4
   - private/waiter
-  - private/protocol/json/jsonutil
-  - private/protocol/rest
-  - service/iam
-  - service/sts
-  - private/protocol/query
-  - service/s3
-  - private/protocol/query/queryutil
-  - private/protocol/xml/xmlutil
-  - private/protocol/restxml
-- name: github.com/bgentry/speakeasy
-  version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
-- name: github.com/boltdb/bolt
-  version: 0b00effdd7a8270ebd91c24297e51643e370dd52
+  - service/dynamodb
+  - service/dynamodb/dynamodbattribute
 - name: github.com/BurntSushi/toml
   version: 5c4df71dfe9ac89ef6287afc05e4c1b16ae65a1e
 - name: github.com/coreos/etcd
   version: 37290820de4c76e905a43edded858dc28f2fe2c5
   subpackages:
+  - Godeps/_workspace/src/github.com/ugorji/go/codec
   - Godeps/_workspace/src/golang.org/x/net/context
   - client
-  - etcdmain
-  - Godeps/_workspace/src/github.com/ugorji/go/codec
   - pkg/pathutil
   - pkg/types
-  - Godeps/_workspace/src/github.com/coreos/go-systemd/daemon
-  - Godeps/_workspace/src/github.com/coreos/go-systemd/util
-  - Godeps/_workspace/src/github.com/coreos/pkg/capnslog
-  - Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus
-  - Godeps/_workspace/src/github.com/prometheus/procfs
-  - Godeps/_workspace/src/google.golang.org/grpc
-  - discovery
-  - etcdserver
-  - etcdserver/api/v3rpc
-  - etcdserver/etcdhttp
-  - etcdserver/etcdserverpb
-  - pkg/cors
-  - pkg/fileutil
-  - pkg/flags
-  - pkg/ioutil
-  - pkg/osutil
-  - pkg/runtime
-  - pkg/transport
-  - proxy
-  - rafthttp
-  - version
-  - Godeps/_workspace/src/github.com/coreos/go-systemd/journal
-  - Godeps/_workspace/src/github.com/beorn7/perks/quantile
-  - Godeps/_workspace/src/github.com/golang/protobuf/proto
-  - Godeps/_workspace/src/github.com/prometheus/client_model/go
-  - Godeps/_workspace/src/github.com/prometheus/common/expfmt
-  - Godeps/_workspace/src/golang.org/x/net/trace
-  - Godeps/_workspace/src/google.golang.org/grpc/codes
-  - Godeps/_workspace/src/google.golang.org/grpc/credentials
-  - Godeps/_workspace/src/google.golang.org/grpc/grpclog
-  - Godeps/_workspace/src/google.golang.org/grpc/metadata
-  - Godeps/_workspace/src/google.golang.org/grpc/naming
-  - Godeps/_workspace/src/google.golang.org/grpc/transport
-  - Godeps/_workspace/src/github.com/jonboulle/clockwork
-  - Godeps/_workspace/src/github.com/coreos/go-semver/semver
-  - Godeps/_workspace/src/github.com/gogo/protobuf/proto
-  - error
-  - etcdserver/etcdhttp/httptypes
-  - etcdserver/stats
-  - lease
-  - lease/leasehttp
-  - pkg/idutil
-  - pkg/netutil
-  - pkg/pbutil
-  - pkg/testutil
-  - pkg/timeutil
-  - pkg/wait
-  - raft
-  - raft/raftpb
-  - snap
-  - storage
-  - storage/backend
-  - storage/storagepb
-  - store
-  - wal
-  - wal/walpb
-  - etcdserver/auth
-  - pkg/logutil
-  - pkg/httputil
-  - Godeps/_workspace/src/github.com/xiang90/probing
-  - Godeps/_workspace/src/bitbucket.org/ww/goautoneg
-  - Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil
-  - Godeps/_workspace/src/github.com/prometheus/common/model
-  - Godeps/_workspace/src/golang.org/x/net/internal/timeseries
-  - Godeps/_workspace/src/golang.org/x/net/http2
-  - Godeps/_workspace/src/golang.org/x/net/http2/hpack
-  - Godeps/_workspace/src/google.golang.org/grpc/peer
-  - lease/leasepb
-  - snap/snappb
-  - Godeps/_workspace/src/github.com/google/btree
-  - Godeps/_workspace/src/github.com/boltdb/bolt
-  - pkg/crc
-  - Godeps/_workspace/src/golang.org/x/crypto/bcrypt
-  - Godeps/_workspace/src/golang.org/x/crypto/blowfish
-- name: github.com/DataDog/datadog-go
-  version: bc97e0770ad4edae1c9dc14beb40b79b2dde32f8
-  subpackages:
-  - statsd
-- name: github.com/duosecurity/duo_api_golang
-  version: 16da9e74793f6d9b97b227a0696fe32bcdaecb42
-  subpackages:
-  - authapi
-- name: github.com/elazarl/go-bindata-assetfs
-  version: 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
 - name: github.com/fatih/structs
   version: a924a2250d1033753512e95dce41dca3fd793ad9
-- name: github.com/fsouza/go-dockerclient
-  version: 0099401a7342ad77e71ca9f9a57c5e72fb80f6b2
-  subpackages:
-  - external/github.com/docker/docker/opts
-  - external/github.com/docker/docker/pkg/archive
-  - external/github.com/docker/docker/pkg/fileutils
-  - external/github.com/docker/docker/pkg/homedir
-  - external/github.com/docker/docker/pkg/stdcopy
-  - external/github.com/hashicorp/go-cleanhttp
-  - external/github.com/Sirupsen/logrus
-  - external/github.com/docker/docker/pkg/idtools
-  - external/github.com/docker/docker/pkg/ioutils
-  - external/github.com/docker/docker/pkg/pools
-  - external/github.com/docker/docker/pkg/promise
-  - external/github.com/docker/docker/pkg/system
-  - external/github.com/opencontainers/runc/libcontainer/user
-  - external/golang.org/x/net/context
 - name: github.com/garyburd/redigo
   version: 836b6e58b3358112c8291565d01c35b8764070d7
   subpackages:
-  - redis
   - internal
+  - redis
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
   version: afbd495e5aaea13597b5e14fe514ddeaa4d76fc3
-- name: github.com/go-ldap/ldap
-  version: f24903dc69b694cd18db4724d714ac47e4fad4f2
-- name: github.com/go-sql-driver/mysql
-  version: 7c7f556282622f94213bc028b4d0a7b6151ba239
-- name: github.com/gocql/gocql
-  version: 4fd9e05d55bae4c3732f98ef4e8aa7f006ead320
-  subpackages:
-  - internal/lru
-  - internal/murmur
-  - internal/streams
-- name: github.com/golang/snappy
-  version: 723cc1e459b8eea2dea4583200fd60757d40097a
-- name: github.com/google/go-github
-  version: b8b4ac742977310ff6e75140a403a38dab109977
-  subpackages:
-  - github
-- name: github.com/google/go-querystring
-  version: 2a60fc2ba6c19de80291203597d752e9ba58e4c0
-  subpackages:
-  - query
-- name: github.com/hailocab/go-hostpool
-  version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/hashicorp/consul
   version: 40707934d26803d22c112f1bf37ce8e0e447901b
   subpackages:
   - api
-  - command
-  - command/agent
-  - consul
-  - watch
-  - consul/state
-  - consul/structs
-  - tlsutil
-  - acl
 - name: github.com/hashicorp/errwrap
   version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
-- name: github.com/hashicorp/go-checkpoint
-  version: e4b2dc34c0f698ee04750bf2035d8b9384233e1b
 - name: github.com/hashicorp/go-cleanhttp
   version: ce617e79981a8fff618bb643d155133a8f38db96
-- name: github.com/hashicorp/go-immutable-radix
-  version: 12e90058b2897552deea141eff51bb7a07a09e63
-- name: github.com/hashicorp/go-memdb
-  version: e16093a4c7dd00f7ce4c2452ded2c7e37d8df8be
-- name: github.com/hashicorp/go-msgpack
-  version: fa3f63826f7c23912c15263591e65d54d080b458
-  subpackages:
-  - codec
 - name: github.com/hashicorp/go-multierror
   version: d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5
-- name: github.com/hashicorp/go-reap
-  version: 2d85522212dcf5a84c6b357094f5c44710441912
-- name: github.com/hashicorp/go-syslog
-  version: 42a2b573b664dbf281bd48c3cc12c086b17a39ba
-- name: github.com/hashicorp/go-uuid
-  version: 36289988d83ca270bc07c234c36f364b0dd9c9a7
-- name: github.com/hashicorp/golang-lru
-  version: 5c7531c003d8bf158b0fe5063649a2f41a822146
-  subpackages:
-  - simplelru
 - name: github.com/hashicorp/hcl
   version: 4de51957ef8d4aba6e285ddfc587633bbfc7c0e8
   subpackages:
   - hcl
   - json
-- name: github.com/hashicorp/logutils
-  version: 0dc08b1671f34c4250ce212759ebd880f743d883
-- name: github.com/hashicorp/memberlist
-  version: 9888dc523910e5d22c5be4f6e34520943df21809
-- name: github.com/hashicorp/net-rpc-msgpackrpc
-  version: a14192a58a694c123d8fe5481d4a4727d6ae82f3
-- name: github.com/hashicorp/raft
-  version: 057b893fd996696719e98b6c44649ea14968c811
-- name: github.com/hashicorp/raft-boltdb
-  version: d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee
-- name: github.com/hashicorp/scada-client
-  version: 84989fd23ad4cc0e7ad44d6a871fd793eb9beb0a
 - name: github.com/hashicorp/serf
   version: e4ec8cc423bbe20d26584b96efbeb9102e16d05f
   subpackages:
   - coordinate
-  - serf
 - name: github.com/hashicorp/vault
   version: 47309289ae8f53ff97be17a4ab21b4a5afa317ef
   subpackages:
   - api
-  - cli
-  - audit
-  - builtin/audit/file
-  - builtin/audit/syslog
-  - builtin/credential/app-id
-  - builtin/credential/cert
-  - builtin/credential/github
-  - builtin/credential/ldap
-  - builtin/credential/userpass
-  - builtin/logical/aws
-  - builtin/logical/cassandra
-  - builtin/logical/consul
-  - builtin/logical/mysql
-  - builtin/logical/pki
-  - builtin/logical/postgresql
-  - builtin/logical/ssh
-  - builtin/logical/transit
-  - command
-  - logical
-  - version
-  - helper/salt
-  - logical/framework
-  - helper/certutil
-  - helper/mfa
-  - helper/password
-  - helper/kdf
-  - command/server
-  - command/token
-  - helper/flag-kv
-  - helper/flag-slice
-  - helper/gated-writer
-  - helper/kv-builder
-  - helper/mlock
-  - helper/pgpkeys
-  - helper/xor
-  - http
-  - physical
-  - vault
-  - helper/mfa/duo
-  - shamir
-- name: github.com/hashicorp/yamux
-  version: df949784da9ed028ee76df44652e42d37a09d7e4
-- name: github.com/inconshreveable/muxado
-  version: f693c7e88ba316d1a0ae3e205e22a01aa3ec2848
-  subpackages:
-  - proto
-  - proto/ext
-  - proto/frame
-  - proto/buffer
 - name: github.com/jmespath/go-jmespath
   version: c01cf91b011868172fdcd9f41838e80c9d716264
-- name: github.com/lib/pq
-  version: 8ad2b298cadd691a77015666a5372eae5dbfac8f
-  subpackages:
-  - oid
 - name: github.com/magiconair/properties
   version: c81f9d71af8f8cba1466501d30326b99a4e56c19
-- name: github.com/mattn/go-isatty
-  version: 56b76bdf51f7708750eac80fa38b952bb9f32639
-- name: github.com/miekg/dns
-  version: 83f7d658ac219335d42f7ec4397a76e35ca7f835
-- name: github.com/mitchellh/cli
-  version: 5c87c51cedf76a1737bf5ca3979e8644871598a6
-- name: github.com/mitchellh/copystructure
-  version: 6fc66267e9da7d155a9d3bd489e00dad02666dc6
-- name: github.com/mitchellh/go-homedir
-  version: d682a8f0cf139663a984ff12528da460ca963de9
 - name: github.com/mitchellh/mapstructure
   version: 281073eb9eb092240d33ef253c404f1cca550309
-- name: github.com/mitchellh/reflectwalk
-  version: eecf4c70c626c7cfbb95c90195bc34d386c74ac6
 - name: github.com/op/go-logging
   version: 0882c9abce533ab4afbab5677fcef7434dd36d5a
-- name: github.com/ryanuber/columnize
-  version: 983d3a5fab1bf04d1b412465d2d9f8430e2e917e
-- name: github.com/samuel/go-zookeeper
-  version: 218e9c81c0dd8b3b18172b2bbfad92cc7d6db55f
-  subpackages:
-  - zk
-- name: golang.org/x/crypto
-  version: 1351f936d976c60a0a48d728281922cf63eafb8d
-  subpackages:
-  - bcrypt
-  - blowfish
-  - ssh
-  - ssh/agent
-  - ssh/terminal
-  - openpgp
-  - openpgp/packet
-  - openpgp/armor
-  - openpgp/errors
-  - openpgp/s2k
-  - cast5
-  - openpgp/elgamal
-- name: golang.org/x/net
-  version: 04b9de9b512f58addf28c9853d50ebef61c3953e
-  subpackages:
-  - context
-  - http2
-  - internal/timeseries
-  - trace
-- name: golang.org/x/oauth2
-  version: 8a57ed94ffd43444c0879fe75701732a38afc985
-  subpackages:
-  - internal
-- name: golang.org/x/sys
-  version: 9c60d1c508f5134d1ca726b4641db998f2523357
-  subpackages:
-  - unix
-- name: gopkg.in/asn1-ber.v1
-  version: 4e86f4367175e39f69d9358a5f17b4dda270378d
-- name: gopkg.in/inf.v0
-  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: f7716cbe52baa25d2e9b0d0da546fcf909fc16b4
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/zeroturnaround/configo
+package: github.com/yoyowallet/configo
 import:
 - package: github.com/BurntSushi/toml
 - package: github.com/ahmetalpbalkan/go-linq

--- a/main.go
+++ b/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	. "github.com/ahmetalpbalkan/go-linq"
-	"github.com/op/go-logging"
-	"github.com/zeroturnaround/configo/exec"
-	"github.com/zeroturnaround/configo/flatmap"
-	"github.com/zeroturnaround/configo/sources"
 	"os"
 	"strconv"
 	"strings"
+
+	. "github.com/ahmetalpbalkan/go-linq"
+	"github.com/op/go-logging"
+	"github.com/yoyowallet/configo/exec"
+	"github.com/yoyowallet/configo/flatmap"
+	"github.com/yoyowallet/configo/sources"
 )
 
 const envVariablePrefix = "CONFIGO_SOURCE_"

--- a/main.go
+++ b/main.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 
 	. "github.com/ahmetalpbalkan/go-linq"
 	"github.com/op/go-logging"
-	"github.com/yoyowallet/configo/exec"
 	"github.com/yoyowallet/configo/flatmap"
 	"github.com/yoyowallet/configo/sources"
 )
@@ -78,7 +79,14 @@ func main() {
 		panic(err)
 	}
 
-	exec.Execute(strings.Join(os.Args[1:], " "))
+	commandPath, err := exec.LookPath(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+
+	if err = syscall.Exec(commandPath, os.Args[1:], os.Environ()); err != nil {
+		panic(err)
+	}
 }
 
 func resolveAll(environ []string) error {

--- a/sources/composite.go
+++ b/sources/composite.go
@@ -2,8 +2,9 @@ package sources
 
 import (
 	"fmt"
+
 	. "github.com/ahmetalpbalkan/go-linq"
-	"github.com/zeroturnaround/configo/flatmap"
+	"github.com/yoyowallet/configo/flatmap"
 )
 
 type CompositeSource struct {

--- a/sources/file.go
+++ b/sources/file.go
@@ -1,8 +1,9 @@
 package sources
 
 import (
-	"github.com/zeroturnaround/configo/parsers"
 	"io/ioutil"
+
+	"github.com/yoyowallet/configo/parsers"
 )
 
 type FileSource struct {

--- a/sources/http.go
+++ b/sources/http.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/zeroturnaround/configo/parsers"
+	"github.com/yoyowallet/configo/parsers"
 )
 
 type HTTPSource struct {

--- a/sources/shell.go
+++ b/sources/shell.go
@@ -1,8 +1,8 @@
 package sources
 
 import (
-	"github.com/zeroturnaround/configo/exec"
-	"github.com/zeroturnaround/configo/parsers"
+	"github.com/yoyowallet/configo/exec"
+	"github.com/yoyowallet/configo/parsers"
 )
 
 type ShellSource struct {

--- a/templates.go
+++ b/templates.go
@@ -3,12 +3,13 @@ package main
 import (
 	"bytes"
 	"errors"
-	. "github.com/ahmetalpbalkan/go-linq"
-	"github.com/op/go-logging"
-	"github.com/zeroturnaround/configo/parsers"
 	"os"
 	"strings"
 	"text/template"
+
+	. "github.com/ahmetalpbalkan/go-linq"
+	"github.com/op/go-logging"
+	"github.com/yoyowallet/configo/parsers"
 )
 
 const configoPrefix = "CONFIGO:"


### PR DESCRIPTION
At the moment, UNIX signals like SIGTERM, SIGUSR1, etc.. are not being forwarded properly. Using `syscall.Exec()` to actually run the command would fix this.