### PR TITLE
Modify DynamoDB backend to use default credential chain

### DIFF
--- a/sources/dynamodb.go
+++ b/sources/dynamodb.go
@@ -20,7 +20,7 @@ type DynamoDBSource struct {
 
 func (dynamoDBSource *DynamoDBSource) Get() (map[string]interface{}, error) {
 
-	config := defaults.Config()
+	config := defaults.Get().Config
 
 	if dynamoDBSource.AccessKey != "" {
 		config = config.WithCredentials(credentials.NewCredentials(&credentials.StaticProvider{


### PR DESCRIPTION
Modify the DynamoDB backend to use the [default credential chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).

[Check out the comment on recommended usage here](https://github.com/aws/aws-sdk-go/blob/master/aws/defaults/defaults.go#L48-L50).